### PR TITLE
Add command to list profiles

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,29 @@ described in the table below:
 | `--event-reader-url` | `AUTOPGO_EVENT_READER_URL` |  None   | Specifies the event bus to use for consuming profile events. See the documentation on [URLs](#url-configuration) for more details                |
 |  `--blob-store-url`  |  `AUTOPGO_BLOB_STORE_URL`  |  None   | Specifies the blob storage provider to use for reading & writing profiles.  See the documentation on [URLs](#url-configuration) for more details |
 
+### Target
+
+The target command is used to spin up a basic HTTP application that exposes pprof endpoints. This is to be used as a
+test target for the [scraper](#scraper).
+
+#### Command
+
+To run the sample target, use the following command:
+
+```shell
+autopgo target
+```
+
+#### Configuration
+
+The `target` command also accepts some command-line flags that may also be set via environment variables. They are
+described in the table below:
+
+|        Flag         | Environment Variable | Default | Description                                                                              |
+|:-------------------:|:--------------------:|:-------:|:-----------------------------------------------------------------------------------------|
+| `--log-level`, `-l` | `AUTOPGO_LOG_LEVEL`  | `info`  | Controls the verbosity of log output, valid values are `debug`, `info`, `warn` & `error` |
+|   `--port`, `-p`    |    `AUTOPGO_PORT`    | `8081`  | Specifies the port to use for HTTP traffic                                               |
+
 ## Events
 
 The [server](#server) and [worker](#worker) components communicate via events published to and read from an event bus.
@@ -261,25 +284,24 @@ described in the table below:
 |  `--api-url`, `-u`  |  `AUTOPGO_API_URL`   | `http://localhost:8080` | The base URL of the profile server where the specified profile will be sent              |
 |  `--output`, `-o`   |   `AUTOPGO_OUTPUT`   |      `default.pgo`      | The location on the local file system to store the downloaded profile.                   |
 
-### Target
+### List
 
-The target command is used to spin up a basic HTTP application that exposes pprof endpoints. This is to be used as a
-test target for the [scraper](#scraper).
+The CLI provides a `list` command that can be used to list all merged profiles managed by the [server](#server).
 
 #### Command
 
-To run the sample target, use the following command:
+To list profiles, use the following command:
 
 ```shell
-autopgo target
+autopgo list
 ```
 
 #### Configuration
 
-The `target` command also accepts some command-line flags that may also be set via environment variables. They are
+The `list` command also accepts some command-line flags that may also be set via environment variables. They are
 described in the table below:
 
-|        Flag         | Environment Variable | Default | Description                                                                              |
-|:-------------------:|:--------------------:|:-------:|:-----------------------------------------------------------------------------------------|
-| `--log-level`, `-l` | `AUTOPGO_LOG_LEVEL`  | `info`  | Controls the verbosity of log output, valid values are `debug`, `info`, `warn` & `error` |
-|   `--port`, `-p`    |    `AUTOPGO_PORT`    | `8081`  | Specifies the port to use for HTTP traffic                                               |
+|        Flag         | Environment Variable |         Default         | Description                                                                              |
+|:-------------------:|:--------------------:|:-----------------------:|:-----------------------------------------------------------------------------------------|
+| `--log-level`, `-l` | `AUTOPGO_LOG_LEVEL`  |         `info`          | Controls the verbosity of log output, valid values are `debug`, `info`, `warn` & `error` |
+|  `--api-url`, `-u`  |  `AUTOPGO_API_URL`   | `http://localhost:8080` | The base URL of the profile server where the specified profile will be sent              |

--- a/cmd/list/list.go
+++ b/cmd/list/list.go
@@ -1,0 +1,52 @@
+// Package list provides the command-line entrypoint to the list command.
+package list
+
+import (
+	"fmt"
+	"os"
+	"path"
+	"text/tabwriter"
+
+	"github.com/spf13/cobra"
+
+	"github.com/davidsbond/autopgo/pkg/client"
+)
+
+// Command returns a cobra.Command instance that allows listing and printing profile information from the CLI.
+func Command() *cobra.Command {
+	var (
+		apiURL string
+	)
+
+	cmd := &cobra.Command{
+		Use:     "list",
+		Short:   "List all profiles",
+		Long:    "Prints information on all profiles currently stored within the server",
+		GroupID: "utils",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx := cmd.Context()
+			profiles, err := client.New(apiURL).List(ctx)
+			if err != nil {
+				return err
+			}
+
+			writer := tabwriter.NewWriter(os.Stdout, 4, 1, 2, ' ', tabwriter.TabIndent)
+			if _, err = fmt.Fprintln(writer, "NAME\tSIZE\tLAST MODIFIED"); err != nil {
+				return err
+			}
+
+			for _, profile := range profiles {
+				if _, err = fmt.Fprintf(writer, "%s\t%d\t%s\n", path.Dir(profile.Key), profile.Size, profile.LastModified); err != nil {
+					return err
+				}
+			}
+
+			return writer.Flush()
+		},
+	}
+
+	flags := cmd.PersistentFlags()
+	flags.StringVarP(&apiURL, "api-url", "u", "http://localhost:8080", "Base URL of the autopgo server.")
+
+	return cmd
+}

--- a/cmd/target/target.go
+++ b/cmd/target/target.go
@@ -19,7 +19,7 @@ func Command() *cobra.Command {
 		Short: "Run an example scraping target",
 		Long: "Starts a basic HTTP application that exposes pprof endpoints. This can be used to test the scraper\n" +
 			"component.",
-		GroupID: "utils",
+		GroupID: "component",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := cmd.Context()
 

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -1,0 +1,48 @@
+// Package api provides types and functions used for uniform handling of HTTP responses and errors.
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"net/http"
+
+	"github.com/davidsbond/autopgo/internal/logger"
+)
+
+type (
+	// The Error type represents an error as returned by the API.
+	Error struct {
+		// The error message.
+		Message string `json:"message"`
+		// The HTTP status code.
+		Code int `json:"code"`
+	}
+)
+
+func (e Error) Error() string {
+	return fmt.Sprintf("%s (%d)", e.Message, e.Code)
+}
+
+// ErrorResponse writes a JSON-encoded Error to the http.ResponseWriter.
+func ErrorResponse(ctx context.Context, w http.ResponseWriter, message string, code int) {
+	e := Error{
+		Message: message,
+		Code:    code,
+	}
+
+	Respond(ctx, w, code, e)
+}
+
+// Respond writes a JSON-encoded HTTP response to the http.ResponseWriter.
+func Respond(ctx context.Context, w http.ResponseWriter, code int, body any) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(code)
+
+	if err := json.NewEncoder(w).Encode(body); err != nil {
+		logger.FromContext(ctx).
+			With(slog.String("error", err.Error())).
+			ErrorContext(ctx, "failed to write response")
+	}
+}

--- a/internal/profile/mocks/BlobRepository.go
+++ b/internal/profile/mocks/BlobRepository.go
@@ -4,6 +4,9 @@ package mocks
 
 import (
 	context "context"
+
+	blob "github.com/davidsbond/autopgo/internal/blob"
+
 	io "io"
 
 	mock "github.com/stretchr/testify/mock"
@@ -65,6 +68,65 @@ func (_c *MockBlobRepository_Delete_Call) Return(_a0 error) *MockBlobRepository_
 }
 
 func (_c *MockBlobRepository_Delete_Call) RunAndReturn(run func(context.Context, string) error) *MockBlobRepository_Delete_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// List provides a mock function with given fields: ctx, filter
+func (_m *MockBlobRepository) List(ctx context.Context, filter blob.ListFilter) ([]blob.Object, error) {
+	ret := _m.Called(ctx, filter)
+
+	if len(ret) == 0 {
+		panic("no return value specified for List")
+	}
+
+	var r0 []blob.Object
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context, blob.ListFilter) ([]blob.Object, error)); ok {
+		return rf(ctx, filter)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context, blob.ListFilter) []blob.Object); ok {
+		r0 = rf(ctx, filter)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]blob.Object)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context, blob.ListFilter) error); ok {
+		r1 = rf(ctx, filter)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// MockBlobRepository_List_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'List'
+type MockBlobRepository_List_Call struct {
+	*mock.Call
+}
+
+// List is a helper method to define mock.On call
+//   - ctx context.Context
+//   - filter blob.ListFilter
+func (_e *MockBlobRepository_Expecter) List(ctx interface{}, filter interface{}) *MockBlobRepository_List_Call {
+	return &MockBlobRepository_List_Call{Call: _e.mock.On("List", ctx, filter)}
+}
+
+func (_c *MockBlobRepository_List_Call) Run(run func(ctx context.Context, filter blob.ListFilter)) *MockBlobRepository_List_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(context.Context), args[1].(blob.ListFilter))
+	})
+	return _c
+}
+
+func (_c *MockBlobRepository_List_Call) Return(_a0 []blob.Object, _a1 error) *MockBlobRepository_List_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *MockBlobRepository_List_Call) RunAndReturn(run func(context.Context, blob.ListFilter) ([]blob.Object, error)) *MockBlobRepository_List_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/internal/profile/profile.go
+++ b/internal/profile/profile.go
@@ -6,6 +6,7 @@ import (
 	"time"
 	"unicode/utf8"
 
+	"github.com/davidsbond/autopgo/internal/blob"
 	"github.com/davidsbond/autopgo/internal/event"
 )
 
@@ -21,6 +22,8 @@ type (
 		// Delete should remove data stored under the given key from the blob store. It should return blob.ErrNotExist
 		// if no object exists at the given key.
 		Delete(ctx context.Context, key string) error
+		// List should return all objects within the repository that match the provided filter.
+		List(ctx context.Context, filter blob.ListFilter) ([]blob.Object, error)
 	}
 
 	// The EventWriter interface describes types that can publish events onto an event bus such as Kafka, NATS, SQS

--- a/main.go
+++ b/main.go
@@ -18,6 +18,7 @@ import (
 	"github.com/spf13/viper"
 
 	"github.com/davidsbond/autopgo/cmd/download"
+	"github.com/davidsbond/autopgo/cmd/list"
 	"github.com/davidsbond/autopgo/cmd/scrape"
 	"github.com/davidsbond/autopgo/cmd/server"
 	"github.com/davidsbond/autopgo/cmd/target"
@@ -82,6 +83,7 @@ func main() {
 		server.Command(),
 		scrape.Command(),
 		target.Command(),
+		list.Command(),
 	)
 
 	flags := cmd.PersistentFlags()


### PR DESCRIPTION
This commit makes a few changes, predominantly adding a new command to allow users to list profiles stored within the server. On top of this the API has also been reworked to return JSON-encoded errors and responses.