### PR TITLE
Add command to delete profile

### DIFF
--- a/README.md
+++ b/README.md
@@ -267,7 +267,7 @@ The CLI provides a `download` command that can be used to download a merged prof
 
 #### Command
 
-To upload a profile, use the following command, specifying the application name as the only argument:
+To download a profile, use the following command, specifying the application name as the only argument:
 
 ```shell
 autopgo download hello-world
@@ -299,6 +299,28 @@ autopgo list
 #### Configuration
 
 The `list` command also accepts some command-line flags that may also be set via environment variables. They are
+described in the table below:
+
+|        Flag         | Environment Variable |         Default         | Description                                                                              |
+|:-------------------:|:--------------------:|:-----------------------:|:-----------------------------------------------------------------------------------------|
+| `--log-level`, `-l` | `AUTOPGO_LOG_LEVEL`  |         `info`          | Controls the verbosity of log output, valid values are `debug`, `info`, `warn` & `error` |
+|  `--api-url`, `-u`  |  `AUTOPGO_API_URL`   | `http://localhost:8080` | The base URL of the profile server where the specified profile will be sent              |
+
+### Delete
+
+The CLI provides a `delete` command that can be used to delete a merged profile from the [server](#server).
+
+#### Command
+
+To download a profile, use the following command, specifying the application name as the only argument:
+
+```shell
+autopgo delete hello-world
+```
+
+#### Configuration
+
+The `delete` command also accepts some command-line flags that may also be set via environment variables. They are
 described in the table below:
 
 |        Flag         | Environment Variable |         Default         | Description                                                                              |

--- a/cmd/delete/delete.go
+++ b/cmd/delete/delete.go
@@ -1,0 +1,43 @@
+// Package delete provides the command for removing a profile from the server.
+package delete
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	"github.com/davidsbond/autopgo/internal/profile"
+	"github.com/davidsbond/autopgo/pkg/client"
+)
+
+// Command returns a cobra.Command instance used for the delete command.
+func Command() *cobra.Command {
+	var (
+		apiURL string
+	)
+
+	cmd := &cobra.Command{
+		Use:     "delete",
+		Short:   "Delete a profile",
+		GroupID: "utils",
+		Args:    cobra.ExactArgs(1),
+		Long: "Deletes the profile for an application. This will also delete profiles pending merge for the application.\n\n" +
+			"This command will not prevent further profiles from being created if they are still being scraped, so you\n" +
+			"should stop all scraping prior to using this command unless you want to start profiling from scratch.",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			app := args[0]
+			ctx := cmd.Context()
+
+			if !profile.IsValidAppName(app) {
+				return fmt.Errorf("%s is not a valid application name", app)
+			}
+
+			return client.New(apiURL).Delete(ctx, app)
+		},
+	}
+
+	flags := cmd.PersistentFlags()
+	flags.StringVarP(&apiURL, "api-url", "u", "http://localhost:8080", "Base URL of the autopgo server")
+
+	return cmd
+}

--- a/internal/profile/mocks/BlobRepository.go
+++ b/internal/profile/mocks/BlobRepository.go
@@ -9,6 +9,8 @@ import (
 
 	io "io"
 
+	iter "iter"
+
 	mock "github.com/stretchr/testify/mock"
 )
 
@@ -72,34 +74,81 @@ func (_c *MockBlobRepository_Delete_Call) RunAndReturn(run func(context.Context,
 	return _c
 }
 
+// Exists provides a mock function with given fields: ctx, path
+func (_m *MockBlobRepository) Exists(ctx context.Context, path string) (bool, error) {
+	ret := _m.Called(ctx, path)
+
+	if len(ret) == 0 {
+		panic("no return value specified for Exists")
+	}
+
+	var r0 bool
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context, string) (bool, error)); ok {
+		return rf(ctx, path)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context, string) bool); ok {
+		r0 = rf(ctx, path)
+	} else {
+		r0 = ret.Get(0).(bool)
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context, string) error); ok {
+		r1 = rf(ctx, path)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// MockBlobRepository_Exists_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'Exists'
+type MockBlobRepository_Exists_Call struct {
+	*mock.Call
+}
+
+// Exists is a helper method to define mock.On call
+//   - ctx context.Context
+//   - path string
+func (_e *MockBlobRepository_Expecter) Exists(ctx interface{}, path interface{}) *MockBlobRepository_Exists_Call {
+	return &MockBlobRepository_Exists_Call{Call: _e.mock.On("Exists", ctx, path)}
+}
+
+func (_c *MockBlobRepository_Exists_Call) Run(run func(ctx context.Context, path string)) *MockBlobRepository_Exists_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(context.Context), args[1].(string))
+	})
+	return _c
+}
+
+func (_c *MockBlobRepository_Exists_Call) Return(_a0 bool, _a1 error) *MockBlobRepository_Exists_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *MockBlobRepository_Exists_Call) RunAndReturn(run func(context.Context, string) (bool, error)) *MockBlobRepository_Exists_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // List provides a mock function with given fields: ctx, filter
-func (_m *MockBlobRepository) List(ctx context.Context, filter blob.ListFilter) ([]blob.Object, error) {
+func (_m *MockBlobRepository) List(ctx context.Context, filter blob.ListFilter) iter.Seq2[blob.Object, error] {
 	ret := _m.Called(ctx, filter)
 
 	if len(ret) == 0 {
 		panic("no return value specified for List")
 	}
 
-	var r0 []blob.Object
-	var r1 error
-	if rf, ok := ret.Get(0).(func(context.Context, blob.ListFilter) ([]blob.Object, error)); ok {
-		return rf(ctx, filter)
-	}
-	if rf, ok := ret.Get(0).(func(context.Context, blob.ListFilter) []blob.Object); ok {
+	var r0 iter.Seq2[blob.Object, error]
+	if rf, ok := ret.Get(0).(func(context.Context, blob.ListFilter) iter.Seq2[blob.Object, error]); ok {
 		r0 = rf(ctx, filter)
 	} else {
 		if ret.Get(0) != nil {
-			r0 = ret.Get(0).([]blob.Object)
+			r0 = ret.Get(0).(iter.Seq2[blob.Object, error])
 		}
 	}
 
-	if rf, ok := ret.Get(1).(func(context.Context, blob.ListFilter) error); ok {
-		r1 = rf(ctx, filter)
-	} else {
-		r1 = ret.Error(1)
-	}
-
-	return r0, r1
+	return r0
 }
 
 // MockBlobRepository_List_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'List'
@@ -121,12 +170,12 @@ func (_c *MockBlobRepository_List_Call) Run(run func(ctx context.Context, filter
 	return _c
 }
 
-func (_c *MockBlobRepository_List_Call) Return(_a0 []blob.Object, _a1 error) *MockBlobRepository_List_Call {
-	_c.Call.Return(_a0, _a1)
+func (_c *MockBlobRepository_List_Call) Return(_a0 iter.Seq2[blob.Object, error]) *MockBlobRepository_List_Call {
+	_c.Call.Return(_a0)
 	return _c
 }
 
-func (_c *MockBlobRepository_List_Call) RunAndReturn(run func(context.Context, blob.ListFilter) ([]blob.Object, error)) *MockBlobRepository_List_Call {
+func (_c *MockBlobRepository_List_Call) RunAndReturn(run func(context.Context, blob.ListFilter) iter.Seq2[blob.Object, error]) *MockBlobRepository_List_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/internal/profile/profile.go
+++ b/internal/profile/profile.go
@@ -3,6 +3,7 @@ package profile
 import (
 	"context"
 	"io"
+	"iter"
 	"time"
 	"unicode/utf8"
 
@@ -23,7 +24,9 @@ type (
 		// if no object exists at the given key.
 		Delete(ctx context.Context, key string) error
 		// List should return all objects within the repository that match the provided filter.
-		List(ctx context.Context, filter blob.ListFilter) ([]blob.Object, error)
+		List(ctx context.Context, filter blob.ListFilter) iter.Seq2[blob.Object, error]
+		// Exists should return true if an object exists at the given path.
+		Exists(ctx context.Context, path string) (bool, error)
 	}
 
 	// The EventWriter interface describes types that can publish events onto an event bus such as Kafka, NATS, SQS

--- a/main.go
+++ b/main.go
@@ -17,6 +17,7 @@ import (
 	"github.com/spf13/pflag"
 	"github.com/spf13/viper"
 
+	delete "github.com/davidsbond/autopgo/cmd/delete"
 	"github.com/davidsbond/autopgo/cmd/download"
 	"github.com/davidsbond/autopgo/cmd/list"
 	"github.com/davidsbond/autopgo/cmd/scrape"
@@ -84,6 +85,7 @@ func main() {
 		scrape.Command(),
 		target.Command(),
 		list.Command(),
+		delete.Command(),
 	)
 
 	flags := cmd.PersistentFlags()


### PR DESCRIPTION
This commit adds a new `delete` command to the CLI which will delete any merged or pending profiles for an application.

It also reworks the `Blob.List` method to use an `iter.Seq2` iterator. This seemed like a good place to use it as the underlying gocloud.dev package uses a pre native iterator already, so this saves an additional loop.