### PR TITLE
Add pprof endpoints to all components

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ described in the table below:
 |:-------------------:|:--------------------:|:-----------------------:|:-----------------------------------------------------------------------------------------|
 | `--log-level`, `-l` | `AUTOPGO_LOG_LEVEL`  |         `info`          | Controls the verbosity of log output, valid values are `debug`, `info`, `warn` & `error` |
 |  `--api-url`, `-u`  |  `AUTOPGO_API_URL`   | `http://localhost:8080` | The base URL of the profile server where scraped profiles will be sent                   |
+|   `--port`, `-p`    |    `AUTOPGO_PORT`    |         `8080`          | Specifies the port to use for HTTP traffic                                               |
 
 #### Sampling
 
@@ -133,6 +134,7 @@ described in the table below:
 | `--event-writer-url` | `AUTOPGO_EVENT_WRITER_URL` |  None   | Specifies the event bus to use for publishing profile events. See the documentation on [URLs](#url-configuration) for more details               |
 | `--event-reader-url` | `AUTOPGO_EVENT_READER_URL` |  None   | Specifies the event bus to use for consuming profile events. See the documentation on [URLs](#url-configuration) for more details                |
 |  `--blob-store-url`  |  `AUTOPGO_BLOB_STORE_URL`  |  None   | Specifies the blob storage provider to use for reading & writing profiles.  See the documentation on [URLs](#url-configuration) for more details |
+|    `--port`, `-p`    |       `AUTOPGO_PORT`       | `8080`  | Specifies the port to use for HTTP traffic                                                                                                       |
 
 ## Events
 

--- a/cmd/list/list.go
+++ b/cmd/list/list.go
@@ -4,8 +4,8 @@ package list
 import (
 	"fmt"
 	"os"
-	"path"
 	"text/tabwriter"
+	"time"
 
 	"github.com/spf13/cobra"
 
@@ -36,7 +36,9 @@ func Command() *cobra.Command {
 			}
 
 			for _, profile := range profiles {
-				if _, err = fmt.Fprintf(writer, "%s\t%d\t%s\n", path.Dir(profile.Key), profile.Size, profile.LastModified); err != nil {
+				lastModified := time.Since(profile.LastModified).Truncate(time.Second)
+
+				if _, err = fmt.Fprintf(writer, "%s\t%d\t%s\n", profile.Key, profile.Size, lastModified); err != nil {
 					return err
 				}
 			}

--- a/example.config.json
+++ b/example.config.json
@@ -6,6 +6,14 @@
     {
       "app": "autopgo",
       "address": "http://localhost:8080/debug/pprof/profile"
+    },
+    {
+      "app": "autopgo",
+      "address": "http://localhost:8081/debug/pprof/profile"
+    },
+    {
+      "app": "autopgo",
+      "address": "http://localhost:8082/debug/pprof/profile"
     }
   ]
 }

--- a/internal/profile/server.go
+++ b/internal/profile/server.go
@@ -67,7 +67,7 @@ func (h *HTTPController) Upload(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	now := time.Now().Unix()
+	now := time.Now().UnixNano()
 	key := path.Join(app, "staging", strconv.FormatInt(now, 10))
 	writer, err := h.blobs.NewWriter(ctx, key)
 	if err != nil {
@@ -161,7 +161,7 @@ func (h *HTTPController) List(w http.ResponseWriter, r *http.Request) {
 		}
 
 		profiles = append(profiles, Profile{
-			Key:          item.Key,
+			Key:          path.Dir(item.Key),
 			Size:         item.Size,
 			LastModified: item.LastModified,
 		})

--- a/internal/profile/server_test.go
+++ b/internal/profile/server_test.go
@@ -220,7 +220,7 @@ func TestHTTPController_List(t *testing.T) {
 			Expected: profile.ListResponse{
 				Profiles: []profile.Profile{
 					{
-						Key:          "test/default.pgo",
+						Key:          "test",
 						Size:         1000,
 						LastModified: time.Date(2020, 1, 1, 0, 0, 0, 0, time.UTC),
 					},

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -3,6 +3,7 @@ package server
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/http/pprof"
@@ -55,7 +56,11 @@ func Run(ctx context.Context, config Config) error {
 
 	group, ctx := errgroup.WithContext(ctx)
 	group.Go(func() error {
-		return server.ListenAndServe()
+		err := server.ListenAndServe()
+		if errors.Is(err, http.ErrServerClosed) {
+			return nil
+		}
+		return err
 	})
 	group.Go(func() error {
 		<-ctx.Done()
@@ -69,16 +74,16 @@ func Run(ctx context.Context, config Config) error {
 }
 
 func registerDebug(mux *http.ServeMux) {
-	mux.HandleFunc("/debug/pprof/", pprof.Index)
-	mux.HandleFunc("/debug/pprof/cmdline", pprof.Cmdline)
-	mux.HandleFunc("/debug/pprof/profile", pprof.Profile)
-	mux.HandleFunc("/debug/pprof/symbol", pprof.Symbol)
-	mux.HandleFunc("/debug/pprof/trace", pprof.Trace)
+	mux.HandleFunc("GET /debug/pprof/", pprof.Index)
+	mux.HandleFunc("GET /debug/pprof/cmdline", pprof.Cmdline)
+	mux.HandleFunc("GET /debug/pprof/profile", pprof.Profile)
+	mux.HandleFunc("GET /debug/pprof/symbol", pprof.Symbol)
+	mux.HandleFunc("GET /debug/pprof/trace", pprof.Trace)
 
-	mux.Handle("/debug/pprof/goroutine", pprof.Handler("goroutine"))
-	mux.Handle("/debug/pprof/heap", pprof.Handler("heap"))
-	mux.Handle("/debug/pprof/threadcreate", pprof.Handler("threadcreate"))
-	mux.Handle("/debug/pprof/block", pprof.Handler("block"))
-	mux.Handle("/debug/pprof/allocs", pprof.Handler("allocs"))
-	mux.Handle("/debug/pprof/mutex", pprof.Handler("mutex"))
+	mux.Handle("GET /debug/pprof/goroutine", pprof.Handler("goroutine"))
+	mux.Handle("GET /debug/pprof/heap", pprof.Handler("heap"))
+	mux.Handle("GET /debug/pprof/threadcreate", pprof.Handler("threadcreate"))
+	mux.Handle("GET /debug/pprof/block", pprof.Handler("block"))
+	mux.Handle("GET /debug/pprof/allocs", pprof.Handler("allocs"))
+	mux.Handle("GET /debug/pprof/mutex", pprof.Handler("mutex"))
 }


### PR DESCRIPTION
This commit modifies all components to run an HTTP server that includes pprof endpoints.

The example configuration is now set up to scrape profiles from the scraper, worker and server.