### PR TITLE
Rework scraper configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,45 +37,40 @@ autopgo scrape config.json
 #### Configuration
 
 The `scrape` command accepts a single argument that is a path to a JSON-encoded configuration file that describes the
-sampling behaviour and the targets available to be scraped. Below is an example configuration:
+targets available to be scraped. Below is an example configuration:
 
 ```json5
-{
-  // The maximum number of targets to sample at once.
-  "sampleSize": 3,
-  // How long targets should be profiled for, in seconds.
-  "profileDuration": 30,
-  // How frequently targets should be profiled, in seconds.
-  "scrapeFrequency": 300,
-  // Endpoints that will profile applications.
-  "targets": [
-    {
-      // The application the profile will belong to.
-      "app": "example-app",
-      // The full address pointing to the target's profiling endpoint.
-      "address": "http://localhost:5000/debug/pprof/profile"
-    }
-  ]
-}
+[
+  {
+    // The scheme, host & port combination of the target.
+    "address": "http://localhost:5000",
+    // The path to the pprof profile endpoint, defaults to /debug/pprof/profile.
+    "path": "/debug/pprof/profile"
+  }
+]
 ```
 
 The `scrape` command also accepts some command-line flags that may also be set via environment variables. They are
 described in the table below:
 
-|        Flag         | Environment Variable |         Default         | Description                                                                              |
-|:-------------------:|:--------------------:|:-----------------------:|:-----------------------------------------------------------------------------------------|
-| `--log-level`, `-l` | `AUTOPGO_LOG_LEVEL`  |         `info`          | Controls the verbosity of log output, valid values are `debug`, `info`, `warn` & `error` |
-|  `--api-url`, `-u`  |  `AUTOPGO_API_URL`   | `http://localhost:8080` | The base URL of the profile server where scraped profiles will be sent                   |
-|   `--port`, `-p`    |    `AUTOPGO_PORT`    |         `8080`          | Specifies the port to use for HTTP traffic                                               |
+|         Flag          | Environment Variable  |         Default         | Description                                                                              |
+|:---------------------:|:---------------------:|:-----------------------:|:-----------------------------------------------------------------------------------------|
+|  `--log-level`, `-l`  |  `AUTOPGO_LOG_LEVEL`  |         `info`          | Controls the verbosity of log output, valid values are `debug`, `info`, `warn` & `error` |
+|   `--api-url`, `-u`   |   `AUTOPGO_API_URL`   | `http://localhost:8080` | The base URL of the profile server where scraped profiles will be sent                   |
+|    `--port`, `-p`     |    `AUTOPGO_PORT`     |         `8080`          | Specifies the port to use for HTTP traffic                                               |
+| `--sample-size`, `-s` | `AUTOPGO_SAMPLE_SIZE` |          None           | Specifies the maximum number of targets to profile concurrently                          |
+|     `--app`, `-a`     |     `AUTOPGO_APP`     |          None           | Specifies the the application name that profiles will be uploaded for                    |
+|  `--frequency`, `-f`  |  `AUTOPGO_FREQUENCY`  |          `60s`          | Specifies the interval between profiling runs                                            |
+|  `--duration`, `-d`   |  `AUTOPGO_DURATION`   |          `30s`          | Specifies the amount of time a target will be profiled for                               |
 
 #### Sampling
 
-The sampling behaviour of the scraper is fairly simple. At the interval defined in the `scrapeFrequency` field, a number
-of randomly selected targets (up to the maximum defined in the `sampleSize` field) have their profiling endpoint called
-for the duration defined in the `profileDuration` field.
+The sampling behaviour of the scraper is fairly simple. At the interval defined by the `--frequency` flag, a number
+of randomly selected targets (up to the maximum defined in the `--sample-size` flag) have their profiling endpoint
+called for the duration defined in the `--duration` flag.
 
 These profiles are taken concurrently and streamed to the upstream profile server, whose base URL is defined via the
-`apiUrl` field.
+`--api-url` flag.
 
 ### Server
 

--- a/cmd/worker/worker.go
+++ b/cmd/worker/worker.go
@@ -8,6 +8,7 @@ import (
 	"github.com/davidsbond/autopgo/internal/blob"
 	"github.com/davidsbond/autopgo/internal/closers"
 	"github.com/davidsbond/autopgo/internal/event"
+	"github.com/davidsbond/autopgo/internal/logger"
 	"github.com/davidsbond/autopgo/internal/profile"
 	"github.com/davidsbond/autopgo/internal/server"
 )
@@ -65,6 +66,9 @@ func Command() *cobra.Command {
 			group.Go(func() error {
 				return server.Run(ctx, server.Config{
 					Port: port,
+					Middleware: []server.Middleware{
+						logger.Middleware(logger.FromContext(ctx)),
+					},
 				})
 			})
 

--- a/example.config.json
+++ b/example.config.json
@@ -1,19 +1,14 @@
-{
-  "sampleSize": 10,
-  "profileDuration": 30,
-  "scrapeFrequency": 30,
-  "targets": [
-    {
-      "app": "autopgo",
-      "address": "http://localhost:8080/debug/pprof/profile"
-    },
-    {
-      "app": "autopgo",
-      "address": "http://localhost:8081/debug/pprof/profile"
-    },
-    {
-      "app": "autopgo",
-      "address": "http://localhost:8082/debug/pprof/profile"
-    }
-  ]
-}
+[
+  {
+    "address": "http://localhost:8080",
+    "path": "/debug/pprof/profile"
+  },
+  {
+    "address": "http://localhost:8081",
+    "path": "/debug/pprof/profile"
+  },
+  {
+    "address": "http://localhost:8082",
+    "path": "/debug/pprof/profile"
+  }
+]

--- a/internal/profile/scraper_test.go
+++ b/internal/profile/scraper_test.go
@@ -27,20 +27,21 @@ func TestScraper_Scrape(t *testing.T) {
 			Duration: 5 * time.Second,
 			Config: profile.ScrapeConfig{
 				SampleSize:      3,
-				ProfileDuration: 30,
-				ScrapeFrequency: 1,
+				ProfileDuration: time.Second * 30,
+				App:             "test",
+				ScrapeFrequency: time.Second,
 				Targets: []profile.ScrapeTarget{
 					{
-						App:     "test",
-						Address: "http://localhost:8080/debug/pprof/profile",
+						Address: "http://localhost:8080",
+						Path:    "/debug/pprof/profile",
 					},
 					{
-						App:     "test-1",
-						Address: "http://localhost:8081/debug/pprof/profile",
+						Address: "http://localhost:8081",
+						Path:    "/debug/pprof/profile",
 					},
 					{
-						App:     "test-2",
-						Address: "http://localhost:8082/debug/pprof/profile",
+						Address: "http://localhost:8082",
+						Path:    "/debug/pprof/profile",
 					},
 				},
 			},
@@ -50,11 +51,11 @@ func TestScraper_Scrape(t *testing.T) {
 					Return(nil)
 
 				client.EXPECT().
-					ProfileAndUpload(mock.Anything, "test-1", "http://localhost:8081/debug/pprof/profile", time.Second*30).
+					ProfileAndUpload(mock.Anything, "test", "http://localhost:8081/debug/pprof/profile", time.Second*30).
 					Return(nil)
 
 				client.EXPECT().
-					ProfileAndUpload(mock.Anything, "test-2", "http://localhost:8082/debug/pprof/profile", time.Second*30).
+					ProfileAndUpload(mock.Anything, "test", "http://localhost:8082/debug/pprof/profile", time.Second*30).
 					Return(nil)
 			},
 		},
@@ -93,12 +94,13 @@ func TestScrapeConfig_Validate(t *testing.T) {
 			Name: "valid profile",
 			Config: profile.ScrapeConfig{
 				SampleSize:      10,
-				ProfileDuration: 10,
-				ScrapeFrequency: 30,
+				ProfileDuration: time.Second * 30,
+				ScrapeFrequency: time.Minute,
+				App:             "test",
 				Targets: []profile.ScrapeTarget{
 					{
-						App:     "test",
-						Address: "http://localhost:8080/debug/pprof/profile",
+						Address: "http://localhost:8080",
+						Path:    "/debug/pprof/profile",
 					},
 				},
 			},
@@ -108,8 +110,8 @@ func TestScrapeConfig_Validate(t *testing.T) {
 			ExpectsError: true,
 			Config: profile.ScrapeConfig{
 				SampleSize:      10,
-				ProfileDuration: 10,
-				ScrapeFrequency: 30,
+				ProfileDuration: time.Second * 30,
+				ScrapeFrequency: time.Minute,
 			},
 		},
 		{
@@ -117,11 +119,12 @@ func TestScrapeConfig_Validate(t *testing.T) {
 			ExpectsError: true,
 			Config: profile.ScrapeConfig{
 				SampleSize:      10,
-				ProfileDuration: 10,
+				ProfileDuration: time.Second * 30,
+				App:             "test",
 				Targets: []profile.ScrapeTarget{
 					{
-						App:     "test",
-						Address: "http://localhost:8080/debug/pprof/profile",
+						Address: "http://localhost:8080",
+						Path:    "/debug/pprof/profile",
 					},
 				},
 			},
@@ -131,11 +134,12 @@ func TestScrapeConfig_Validate(t *testing.T) {
 			ExpectsError: true,
 			Config: profile.ScrapeConfig{
 				SampleSize:      10,
-				ScrapeFrequency: 30,
+				ScrapeFrequency: time.Minute,
+				App:             "test",
 				Targets: []profile.ScrapeTarget{
 					{
-						App:     "test",
-						Address: "http://localhost:8080/debug/pprof/profile",
+						Address: "http://localhost:8080",
+						Path:    "/debug/pprof/profile",
 					},
 				},
 			},
@@ -144,26 +148,13 @@ func TestScrapeConfig_Validate(t *testing.T) {
 			Name:         "invalid sample size",
 			ExpectsError: true,
 			Config: profile.ScrapeConfig{
-				ProfileDuration: 10,
-				ScrapeFrequency: 30,
+				ProfileDuration: time.Second * 30,
+				ScrapeFrequency: time.Minute,
+				App:             "test",
 				Targets: []profile.ScrapeTarget{
 					{
-						App:     "test",
-						Address: "http://localhost:8080/debug/pprof/profile",
-					},
-				},
-			},
-		},
-		{
-			Name:         "target missing app",
-			ExpectsError: true,
-			Config: profile.ScrapeConfig{
-				SampleSize:      10,
-				ProfileDuration: 10,
-				ScrapeFrequency: 30,
-				Targets: []profile.ScrapeTarget{
-					{
-						Address: "http://localhost:8080/debug/pprof/profile",
+						Address: "http://localhost:8080",
+						Path:    "/debug/pprof/profile",
 					},
 				},
 			},
@@ -173,12 +164,13 @@ func TestScrapeConfig_Validate(t *testing.T) {
 			ExpectsError: true,
 			Config: profile.ScrapeConfig{
 				SampleSize:      10,
-				ProfileDuration: 10,
-				ScrapeFrequency: 30,
+				ProfileDuration: time.Second * 30,
+				ScrapeFrequency: time.Minute,
+				App:             "_/@~",
 				Targets: []profile.ScrapeTarget{
 					{
-						App:     "_/@~",
-						Address: "http://localhost:8080/debug/pprof/profile",
+						Address: "http://localhost:8080",
+						Path:    "/debug/pprof/profile",
 					},
 				},
 			},
@@ -188,12 +180,11 @@ func TestScrapeConfig_Validate(t *testing.T) {
 			ExpectsError: true,
 			Config: profile.ScrapeConfig{
 				SampleSize:      10,
-				ProfileDuration: 10,
-				ScrapeFrequency: 30,
+				ProfileDuration: time.Second * 30,
+				ScrapeFrequency: time.Minute,
+				App:             "test",
 				Targets: []profile.ScrapeTarget{
-					{
-						App: "test",
-					},
+					{},
 				},
 			},
 		},

--- a/scripts/prepare-dev.sh
+++ b/scripts/prepare-dev.sh
@@ -12,3 +12,5 @@ export AUTOPGO_EVENT_READER_URL="nats://profile?natsv2=true&queue=worker"
 
 export AUTOPGO_LOG_LEVEL=debug
 export AUTOPGO_API_URL="http://localhost:8080"
+export AUTOPGO_APP=autopgo
+export AUTOPGO_SAMPLE_SIZE=10


### PR DESCRIPTION
This commit reworks how the scraper is configured to make it focused on having a single application per scraper. The app value is now set at the top level and all targets profiled by the scraper will be uploaded under a single app.

The reason for this change is that before this, sampling wasn't done per application, so if the scraper was set up with multiple applications there was no way to control sampling per-app. Instead, all targets share the same sample size, which could end up with some apps being sampled more than others.

Rather than add a complicated way of sampling per app, I've just made the scraper responsible for a single app.