### PR TITLE
Add clean command

### DIFF
--- a/README.md
+++ b/README.md
@@ -301,3 +301,28 @@ described in the table below:
 |:-------------------:|:--------------------:|:-----------------------:|:-----------------------------------------------------------------------------------------|
 | `--log-level`, `-l` | `AUTOPGO_LOG_LEVEL`  |         `info`          | Controls the verbosity of log output, valid values are `debug`, `info`, `warn` & `error` |
 |  `--api-url`, `-u`  |  `AUTOPGO_API_URL`   | `http://localhost:8080` | The base URL of the profile server where the specified profile will be sent              |
+
+### Clean
+
+The CLI provides a `clean` command that can be used to remove profiles larger than a specified size or that have not
+been updated for a specified duration.
+
+#### Command
+
+To perform a clean, use the following command, specifying either the `--older-than` or `--larger-than` flags (or both).
+
+```shell
+autopgo clean --older-than 24h --larger-than 10240
+```
+
+#### Configuration
+
+The `clean` command accepts command-line flags that may also be set via environment variables. They are described in the
+table below:
+
+|         Flag          | Environment Variable  |         Default         | Description                                                                              |
+|:---------------------:|:---------------------:|:-----------------------:|:-----------------------------------------------------------------------------------------|
+|  `--log-level`, `-l`  |  `AUTOPGO_LOG_LEVEL`  |         `info`          | Controls the verbosity of log output, valid values are `debug`, `info`, `warn` & `error` |
+|   `--api-url`, `-u`   |   `AUTOPGO_API_URL`   | `http://localhost:8080` | The base URL of the profile server where the specified profile will be sent              |
+| `--older-than`, `-d`  | `AUTOPGO_OLDER_THAN`  |          None           | How long a profile must not have been updated for to be eligible for cleaning            |
+| `--larger-than`, `-s` | `AUTOPGO_LARGER_THAN` |          None           | The minimum size (in bytes) a profile must be to be eligible for cleaning                |

--- a/cmd/clean/clean.go
+++ b/cmd/clean/clean.go
@@ -1,0 +1,61 @@
+// Package clean provides the command for removing old or large profiles from the server.
+package clean
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"github.com/davidsbond/autopgo/pkg/client"
+)
+
+// Command returns a cobra.Command instance that runs the clean command.
+func Command() *cobra.Command {
+	var (
+		apiURL     string
+		olderThan  time.Duration
+		largerThan int64
+	)
+
+	cmd := &cobra.Command{
+		Use:     "clean",
+		Short:   "Clean up profiles",
+		GroupID: "utils",
+		Long: "Deletes profiles that have exceeded a specified size or have not been modified for a specified amount of\n" +
+			"time.\n\n" +
+			"This command is destructive and will not prevent further profiles from being uploaded and merged for\n" +
+			"any of the applications whose profiles are deleted.",
+		Example: "autopgo clean --older-than 48h\n" +
+			"autopgo clean --larger-than 1000000",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx := cmd.Context()
+
+			if largerThan == 0 && olderThan == 0 {
+				return errors.New("one of --older-than or --larger-than must be set")
+			}
+
+			cleaned, err := client.New(apiURL).Clean(ctx, olderThan, largerThan)
+			if err != nil {
+				return err
+			}
+
+			for _, profile := range cleaned {
+				if _, err = fmt.Fprintf(os.Stdout, "Deleted profile '%s'\n", profile); err != nil {
+					return err
+				}
+			}
+
+			return nil
+		},
+	}
+
+	flags := cmd.PersistentFlags()
+	flags.StringVarP(&apiURL, "api-url", "u", "http://localhost:8080", "Base URL of the autopgo server")
+	flags.DurationVarP(&olderThan, "older-than", "d", 0, "The duration a profile must have remained static for")
+	flags.Int64VarP(&largerThan, "larger-than", "s", 0, "The minimum size a profile must be")
+
+	return cmd
+}

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"log/slog"
 	"net/http"
 
@@ -45,4 +46,13 @@ func Respond(ctx context.Context, w http.ResponseWriter, code int, body any) {
 			With(slog.String("error", err.Error())).
 			ErrorContext(ctx, "failed to write response")
 	}
+}
+
+// Decode the contents of the io.Reader into a new instance of type T. Expects a JSON-encoded object.
+func Decode[T any](r io.Reader) (T, error) {
+	var t T
+	if err := json.NewDecoder(r).Decode(&t); err != nil {
+		return t, err
+	}
+	return t, nil
 }

--- a/internal/blob/blob_test.go
+++ b/internal/blob/blob_test.go
@@ -1,0 +1,132 @@
+package blob_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/davidsbond/autopgo/internal/blob"
+)
+
+func TestAll(t *testing.T) {
+	t.Parallel()
+
+	tt := []struct {
+		Name     string
+		Input    blob.Object
+		Filters  []blob.Filter
+		Expected bool
+	}{
+		{
+			Name: "return true if all filters return true",
+			Input: blob.Object{
+				Key:          "test",
+				Size:         1000,
+				LastModified: time.Now(),
+			},
+			Expected: true,
+			Filters: []blob.Filter{
+				func(obj blob.Object) bool {
+					return obj.Key == "test"
+				},
+				func(obj blob.Object) bool {
+					return obj.Size == 1000
+				},
+				func(obj blob.Object) bool {
+					return obj.LastModified.Before(time.Now())
+				},
+			},
+		},
+		{
+			Name: "return false if any filters return false",
+			Input: blob.Object{
+				Key:          "test",
+				Size:         1000,
+				LastModified: time.Now(),
+			},
+			Expected: false,
+			Filters: []blob.Filter{
+				func(obj blob.Object) bool {
+					return obj.Key == "test"
+				},
+				func(obj blob.Object) bool {
+					return obj.Size == 1000
+				},
+				func(obj blob.Object) bool {
+					return obj.LastModified.After(time.Now())
+				},
+			},
+		},
+	}
+
+	for _, tc := range tt {
+		t.Run(tc.Name, func(t *testing.T) {
+			filter := blob.All(tc.Filters...)
+
+			actual := filter(tc.Input)
+			assert.EqualValues(t, tc.Expected, actual)
+		})
+	}
+}
+
+func TestAny(t *testing.T) {
+	t.Parallel()
+
+	tt := []struct {
+		Name     string
+		Input    blob.Object
+		Filters  []blob.Filter
+		Expected bool
+	}{
+		{
+			Name: "return true if any filters return true",
+			Input: blob.Object{
+				Key:          "test",
+				Size:         1000,
+				LastModified: time.Now(),
+			},
+			Expected: true,
+			Filters: []blob.Filter{
+				func(obj blob.Object) bool {
+					return obj.Key == "test"
+				},
+				func(obj blob.Object) bool {
+					return obj.Size == 1000
+				},
+				func(obj blob.Object) bool {
+					return obj.LastModified.After(time.Now())
+				},
+			},
+		},
+		{
+			Name: "return false if no filters return true",
+			Input: blob.Object{
+				Key:          "test",
+				Size:         1000,
+				LastModified: time.Now(),
+			},
+			Expected: false,
+			Filters: []blob.Filter{
+				func(obj blob.Object) bool {
+					return obj.Key == "test1"
+				},
+				func(obj blob.Object) bool {
+					return obj.Size == 10001
+				},
+				func(obj blob.Object) bool {
+					return obj.LastModified.After(time.Now())
+				},
+			},
+		},
+	}
+
+	for _, tc := range tt {
+		t.Run(tc.Name, func(t *testing.T) {
+			filter := blob.Any(tc.Filters...)
+
+			actual := filter(tc.Input)
+			assert.EqualValues(t, tc.Expected, actual)
+		})
+	}
+}

--- a/internal/profile/helpers_test.go
+++ b/internal/profile/helpers_test.go
@@ -1,0 +1,68 @@
+package profile_test
+
+import (
+	"bytes"
+	_ "embed"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+
+	"github.com/davidsbond/autopgo/internal/profile"
+)
+
+var (
+	//go:embed testdata/gobench.cpu
+	validProfile []byte
+)
+
+func appKeyMatcher(app string) any {
+	return mock.MatchedBy(func(s string) bool {
+		return strings.HasPrefix(s, app)
+	})
+}
+
+func uploadedEventMatcher(app string) any {
+	return mock.MatchedBy(func(e profile.UploadedEvent) bool {
+		return e.App == app && strings.HasPrefix(e.ProfileKey, app)
+	})
+}
+
+type (
+	WriteCloser struct {
+		closeError error
+		writeError error
+	}
+
+	ReadCloser struct {
+		readError  error
+		closeError error
+		data       *bytes.Buffer
+	}
+)
+
+func (n *WriteCloser) Write(b []byte) (int, error) {
+	return len(b), n.writeError
+}
+
+func (n *WriteCloser) Close() error { return n.closeError }
+
+func (n *ReadCloser) Read(b []byte) (int, error) {
+	if n.readError != nil {
+		return 0, n.readError
+	}
+
+	return n.data.Read(b)
+}
+
+func (n *ReadCloser) Close() error { return n.closeError }
+
+func mustMarshal(t *testing.T, v interface{}) []byte {
+	t.Helper()
+
+	b, err := json.Marshal(v)
+	require.NoError(t, err)
+	return b
+}

--- a/internal/profile/mocks/BlobRepository.go
+++ b/internal/profile/mocks/BlobRepository.go
@@ -132,7 +132,7 @@ func (_c *MockBlobRepository_Exists_Call) RunAndReturn(run func(context.Context,
 }
 
 // List provides a mock function with given fields: ctx, filter
-func (_m *MockBlobRepository) List(ctx context.Context, filter blob.ListFilter) iter.Seq2[blob.Object, error] {
+func (_m *MockBlobRepository) List(ctx context.Context, filter blob.Filter) iter.Seq2[blob.Object, error] {
 	ret := _m.Called(ctx, filter)
 
 	if len(ret) == 0 {
@@ -140,7 +140,7 @@ func (_m *MockBlobRepository) List(ctx context.Context, filter blob.ListFilter) 
 	}
 
 	var r0 iter.Seq2[blob.Object, error]
-	if rf, ok := ret.Get(0).(func(context.Context, blob.ListFilter) iter.Seq2[blob.Object, error]); ok {
+	if rf, ok := ret.Get(0).(func(context.Context, blob.Filter) iter.Seq2[blob.Object, error]); ok {
 		r0 = rf(ctx, filter)
 	} else {
 		if ret.Get(0) != nil {
@@ -158,14 +158,14 @@ type MockBlobRepository_List_Call struct {
 
 // List is a helper method to define mock.On call
 //   - ctx context.Context
-//   - filter blob.ListFilter
+//   - filter blob.Filter
 func (_e *MockBlobRepository_Expecter) List(ctx interface{}, filter interface{}) *MockBlobRepository_List_Call {
 	return &MockBlobRepository_List_Call{Call: _e.mock.On("List", ctx, filter)}
 }
 
-func (_c *MockBlobRepository_List_Call) Run(run func(ctx context.Context, filter blob.ListFilter)) *MockBlobRepository_List_Call {
+func (_c *MockBlobRepository_List_Call) Run(run func(ctx context.Context, filter blob.Filter)) *MockBlobRepository_List_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(blob.ListFilter))
+		run(args[0].(context.Context), args[1].(blob.Filter))
 	})
 	return _c
 }
@@ -175,7 +175,7 @@ func (_c *MockBlobRepository_List_Call) Return(_a0 iter.Seq2[blob.Object, error]
 	return _c
 }
 
-func (_c *MockBlobRepository_List_Call) RunAndReturn(run func(context.Context, blob.ListFilter) iter.Seq2[blob.Object, error]) *MockBlobRepository_List_Call {
+func (_c *MockBlobRepository_List_Call) RunAndReturn(run func(context.Context, blob.Filter) iter.Seq2[blob.Object, error]) *MockBlobRepository_List_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/internal/profile/profile.go
+++ b/internal/profile/profile.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"io"
 	"iter"
+	"strings"
 	"time"
 	"unicode/utf8"
 
@@ -24,7 +25,7 @@ type (
 		// if no object exists at the given key.
 		Delete(ctx context.Context, key string) error
 		// List should return all objects within the repository that match the provided filter.
-		List(ctx context.Context, filter blob.ListFilter) iter.Seq2[blob.Object, error]
+		List(ctx context.Context, filter blob.Filter) iter.Seq2[blob.Object, error]
 		// Exists should return true if an object exists at the given path.
 		Exists(ctx context.Context, path string) (bool, error)
 	}
@@ -110,4 +111,47 @@ func IsValidAppName(app string) bool {
 	}
 
 	return true
+}
+
+// IsMergedProfile returns a blob.Filter that returns true for any object keys that match those of a merged
+// profile.
+func IsMergedProfile() blob.Filter {
+	return func(obj blob.Object) bool {
+		return strings.HasSuffix(obj.Key, "default.pgo")
+	}
+}
+
+// IsApplication returns a blob.Filter that returns true for any object keys that have the provided application
+// name as a prefix.
+func IsApplication(app string) blob.Filter {
+	return func(obj blob.Object) bool {
+		return strings.HasPrefix(obj.Key, app+"/")
+	}
+}
+
+// IsLargerThan returns a blob.Filter that returns true for any object whose size is larger than the one provided.
+// The size is a byte value. If size is zero then this filter does nothing.
+func IsLargerThan(size int64) blob.Filter {
+	return func(obj blob.Object) bool {
+		if size <= 0 {
+			return false
+		}
+
+		return obj.Size > size
+	}
+}
+
+// IsOlderThan returns a blob.Filter that returns true for any object whose last modified time is older than the
+// specified duration relative to the time this function is called. If the duration is zero then this filter does
+// nothing.
+func IsOlderThan(duration time.Duration) blob.Filter {
+	now := time.Now()
+
+	return func(obj blob.Object) bool {
+		if duration <= 0 {
+			return false
+		}
+
+		return obj.LastModified.Add(duration).Before(now)
+	}
 }

--- a/main.go
+++ b/main.go
@@ -17,6 +17,7 @@ import (
 	"github.com/spf13/pflag"
 	"github.com/spf13/viper"
 
+	"github.com/davidsbond/autopgo/cmd/clean"
 	delete "github.com/davidsbond/autopgo/cmd/delete"
 	"github.com/davidsbond/autopgo/cmd/download"
 	"github.com/davidsbond/autopgo/cmd/list"
@@ -84,6 +85,7 @@ func main() {
 		scrape.Command(),
 		list.Command(),
 		delete.Command(),
+		clean.Command(),
 	)
 
 	flags := cmd.PersistentFlags()

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -1,6 +1,7 @@
 package client
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -204,6 +205,54 @@ func (c *Client) Delete(ctx context.Context, app string) error {
 	}
 
 	return nil
+}
+
+// Clean deletes all profiles that are larger than a specified size or have not been modified for longer than the given
+// duration.
+func (c *Client) Clean(ctx context.Context, olderThan time.Duration, largerThan int64) ([]string, error) {
+	u, err := url.Parse(c.baseURL)
+	if err != nil {
+		return nil, err
+	}
+
+	u.Path = "/api/clean"
+
+	payload := profile.CleanRequest{
+		OlderThan:  olderThan,
+		LargerThan: largerThan,
+	}
+
+	buffer := bytes.NewBuffer(nil)
+	if err = json.NewEncoder(buffer).Encode(&payload); err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, u.String(), buffer)
+	if err != nil {
+		return nil, err
+	}
+
+	logger.FromContext(ctx).With(
+		slog.String("http.url", req.URL.String()),
+		slog.String("http.method", req.Method),
+	).DebugContext(ctx, "performing HTTP request")
+
+	resp, err := c.http.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer closers.Close(ctx, resp.Body)
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, bodyToError(resp.Body)
+	}
+
+	var clean profile.CleanResponse
+	if err = json.NewDecoder(resp.Body).Decode(&clean); err != nil {
+		return nil, err
+	}
+
+	return clean.Cleaned, nil
 }
 
 func bodyToError(body io.Reader) error {


### PR DESCRIPTION
This commit adds the clean command that can be used to remove profiles larger than a specified size or that have not been updated for a minimum duration.

This commit also includes a small refactoring of list filters to allow for combining filters using the `And` and `Any` functions.