### PR TITLE
Use events for profile deletion

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,6 +223,17 @@ Event that indicates an uploaded profile has been merged with the base profile a
 }
 ```
 
+#### profile.deleted
+
+Event that indicates the merged and any pending profiles have been deleted for an application.
+
+```json5
+{
+  // The name of the application that has been deleted.
+  "app": "example-app"
+}
+```
+
 ### URL Configuration
 
 The [server](#server) and [worker](#worker) components both utilise URLs for configuring access to both blob storage and

--- a/cmd/worker/worker.go
+++ b/cmd/worker/worker.go
@@ -70,6 +70,7 @@ func Command() *cobra.Command {
 			types := []string{
 				profile.EventTypeMerged,
 				profile.EventTypeUploaded,
+				profile.EventTypeDeleted,
 			}
 
 			group, ctx := errgroup.WithContext(ctx)

--- a/internal/profile/helpers_test.go
+++ b/internal/profile/helpers_test.go
@@ -30,6 +30,12 @@ func uploadedEventMatcher(app string) any {
 	})
 }
 
+func deletedEventMatcher(app string) any {
+	return mock.MatchedBy(func(e profile.DeletedEvent) bool {
+		return e.App == app
+	})
+}
+
 type (
 	WriteCloser struct {
 		closeError error

--- a/internal/profile/profile.go
+++ b/internal/profile/profile.go
@@ -68,12 +68,19 @@ type (
 		// The location of the base profile that has been merged.
 		MergedKey string `json:"mergedKey"`
 	}
+
+	// The DeletedEvent type is an event.Payload implementation describing a profile that has been deleted.
+	DeletedEvent struct {
+		// The application profile that has been deleted.
+		App string `json:"app"`
+	}
 )
 
 // Constants for event types.
 const (
 	EventTypeUploaded = "profile.uploaded"
 	EventTypeMerged   = "profile.merged"
+	EventTypeDeleted  = "profile.deleted"
 )
 
 // Type returns EventTypeUploaded.
@@ -93,6 +100,16 @@ func (e MergedEvent) Type() string {
 
 // Key returns the application name.
 func (e MergedEvent) Key() string {
+	return e.App
+}
+
+// Type returns EventTypeDeleted.
+func (e DeletedEvent) Type() string {
+	return EventTypeDeleted
+}
+
+// Key returns the application name.
+func (e DeletedEvent) Key() string {
 	return e.App
 }
 

--- a/internal/profile/server.go
+++ b/internal/profile/server.go
@@ -191,20 +191,9 @@ func (h *HTTPController) Delete(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	for object, err := range h.blobs.List(ctx, IsApplication(app)) {
-		if err != nil {
-			api.ErrorResponse(ctx, w, err.Error(), http.StatusInternalServerError)
-			return
-		}
-
-		err = h.blobs.Delete(ctx, object.Key)
-		switch {
-		case errors.Is(err, blob.ErrNotExist):
-			continue
-		case err != nil:
-			api.ErrorResponse(ctx, w, err.Error(), http.StatusInternalServerError)
-			return
-		}
+	if err = h.events.Write(ctx, DeletedEvent{App: app}); err != nil {
+		api.ErrorResponse(ctx, w, err.Error(), http.StatusInternalServerError)
+		return
 	}
 
 	api.Respond(ctx, w, http.StatusOK, DeleteResponse{})

--- a/internal/profile/worker_test.go
+++ b/internal/profile/worker_test.go
@@ -154,6 +154,32 @@ func TestWorker_HandleEvent(t *testing.T) {
 					Return(nil)
 			},
 		},
+		{
+			Name: "handle profile.deleted",
+			Event: event.Envelope{
+				ID:        uuid.NewString(),
+				Timestamp: time.Now(),
+				Type:      profile.EventTypeDeleted,
+				Payload: mustMarshal(t, profile.DeletedEvent{
+					App: "test-app",
+				}),
+			},
+			Setup: func(blobs *mocks.MockBlobRepository, events *mocks.MockEventWriter) {
+				blobs.EXPECT().
+					List(mock.Anything, mock.Anything).
+					Return(func(yield func(blob.Object, error) bool) {
+						yield(blob.Object{
+							Key:          "test-app/default.pgo",
+							Size:         1000,
+							LastModified: time.Now(),
+						}, nil)
+					})
+
+				blobs.EXPECT().
+					Delete(mock.Anything, "test-app/default.pgo").
+					Return(nil)
+			},
+		},
 	}
 
 	for _, tc := range tt {


### PR DESCRIPTION
This commit modifies how profile deletion works by swapping to emitting an event onto the configured event bus which the worker then handles and performs the deletion with.