### PR TITLE
Add SIGHUP support for file mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,8 @@ file should be a JSON array of objects describing where the pprof endpoints are 
 ]
 ```
 
+When using `file` mode, the file can be updated without restarting the scraper using a `SIGHUP` signal.
+
 ##### Kube Mode
 
 When the `mode` flag is set to `kube`, the first argument becomes an optional path to a kubeconfig file. Scraping

--- a/internal/target/file.go
+++ b/internal/target/file.go
@@ -3,21 +3,82 @@ package target
 import (
 	"context"
 	"encoding/json"
+	"log/slog"
 	"os"
+	"os/signal"
+	"sync"
+	"syscall"
 
 	"github.com/davidsbond/autopgo/internal/closers"
+	"github.com/davidsbond/autopgo/internal/logger"
 )
 
 type (
 	// The FileSource type describes a source of targets loaded from a JSON file.
 	FileSource struct {
-		targets []Target
+		location string
+		mux      sync.RWMutex
+		targets  []Target
 	}
 )
 
 // NewFileSource returns a new instance of the FileSource type that loads Target data from the JSON file specified
-// at the given location. The file is expected to contain a JSON-encoded array of the Target type.
+// at the given location. The file is expected to contain a JSON-encoded array of the Target type. The FileSource type
+// will also listen for SIGHUP signals and reread the JSON file and update its list of targets.
 func NewFileSource(ctx context.Context, location string) (*FileSource, error) {
+	targets, err := readTargetsFromFile(ctx, location)
+	if err != nil {
+		return nil, err
+	}
+
+	source := &FileSource{
+		targets:  targets,
+		location: location,
+	}
+
+	go source.handleUpdates(ctx)
+	return source, nil
+}
+
+// List all targets within the file.
+func (fs *FileSource) List(_ context.Context) ([]Target, error) {
+	fs.mux.RLock()
+	defer fs.mux.RUnlock()
+
+	return fs.targets, nil
+}
+
+func (fs *FileSource) handleUpdates(ctx context.Context) {
+	update := make(chan os.Signal, 1)
+	defer close(update)
+
+	signal.Notify(update, syscall.SIGHUP)
+	defer signal.Stop(update)
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-update:
+			log := logger.FromContext(ctx).With(slog.String("file", fs.location))
+
+			targets, err := readTargetsFromFile(ctx, fs.location)
+			if err != nil {
+				log.With(slog.String("error", err.Error())).Error("failed to read updated targets")
+
+				continue
+			}
+
+			fs.mux.Lock()
+			fs.targets = targets
+			fs.mux.Unlock()
+
+			log.Debug("targets updated")
+		}
+	}
+}
+
+func readTargetsFromFile(ctx context.Context, location string) ([]Target, error) {
 	f, err := os.Open(location)
 	if err != nil {
 		return nil, err
@@ -29,10 +90,5 @@ func NewFileSource(ctx context.Context, location string) (*FileSource, error) {
 		return nil, err
 	}
 
-	return &FileSource{targets: targets}, nil
-}
-
-// List all targets within the file.
-func (fs *FileSource) List(_ context.Context) ([]Target, error) {
-	return fs.targets, nil
+	return targets, nil
 }

--- a/internal/target/file_test.go
+++ b/internal/target/file_test.go
@@ -2,7 +2,11 @@ package target_test
 
 import (
 	"context"
+	"encoding/json"
+	"os"
+	"syscall"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -66,5 +70,57 @@ func TestFileSource_List(t *testing.T) {
 			assert.EqualValues(t, tc.Expected, actual)
 		})
 	}
+}
 
+func TestFileSource_SIGHUP(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+
+	f, err := os.CreateTemp(os.TempDir(), "autopgo")
+	require.NoError(t, err)
+
+	// Create a JSON file with a single target initially.
+	targets := []target.Target{
+		{
+			Address: "https://test.com:8080",
+			Path:    "/test",
+		},
+	}
+
+	require.NoError(t, json.NewEncoder(f).Encode(targets))
+	require.NoError(t, f.Close())
+
+	source, err := target.NewFileSource(ctx, f.Name())
+	require.NoError(t, err)
+
+	// Make sure we only have the single target.
+	actual, err := source.List(ctx)
+	require.NoError(t, err)
+	require.EqualValues(t, targets, actual)
+
+	// Rewrite the file with a second target
+	targets = append(targets, target.Target{
+		Address: "https://test.com:8081",
+		Path:    "/test2",
+	})
+
+	f, err = os.Create(f.Name())
+	require.NoError(t, err)
+	require.NoError(t, json.NewEncoder(f).Encode(targets))
+	require.NoError(t, f.Close())
+
+	// Send a SIGHUP to force the target source to reload.
+	require.NoError(t, syscall.Kill(os.Getpid(), syscall.SIGHUP))
+
+	// Make sure the list now has both targets. This is done async so we should check periodically for the updated
+	// list.
+	assert.Eventually(t, func() bool {
+		actual, err = source.List(ctx)
+		require.NoError(t, err)
+		return len(targets) == len(actual)
+	}, time.Minute, time.Second)
+
+	require.EqualValues(t, targets, actual)
 }


### PR DESCRIPTION
This commit modifies the file-based target source to support handling SIGHUP signals for hot-reloading the target file. When using a file source a restart is no longer required once the configuration file has changed.