### PR TITLE
Add logging & docs to nomad mode

### DIFF
--- a/cmd/scrape/scrape.go
+++ b/cmd/scrape/scrape.go
@@ -103,7 +103,7 @@ func Command() *cobra.Command {
 	flags.UintVarP(&sampleSize, "sample-size", "s", 0, "The maximum number of targets to scrape concurrently")
 	flags.DurationVarP(&duration, "duration", "d", time.Second*30, "How long to profile targets for")
 	flags.DurationVarP(&frequency, "frequency", "f", time.Minute, "Interval between scraping targets")
-	flags.StringVarP(&mode, "mode", "m", modeFile, "Mode to use for obtaining targets (file, kube)")
+	flags.StringVarP(&mode, "mode", "m", modeFile, "Mode to use for obtaining targets (file, kube, nomad)")
 
 	cmd.MarkFlagRequired("app")
 	cmd.MarkFlagRequired("sample-size")

--- a/internal/target/nomad.go
+++ b/internal/target/nomad.go
@@ -3,21 +3,28 @@ package target
 import (
 	"context"
 	"fmt"
+	"log/slog"
 	"net"
 	"net/url"
 	"strconv"
 	"strings"
 
 	"github.com/hashicorp/nomad/api"
+
+	"github.com/davidsbond/autopgo/internal/logger"
 )
 
 type (
+	// The NomadSource type is used to source scrapable targets from a HashiCorp Nomad cluster using its services
+	// API.
 	NomadSource struct {
 		client *api.Client
 		filter string
 	}
 )
 
+// NewNomadSource returns a new instance of the NomadSource type that will source targets using the provided Nomad
+// client. It will search for services tagged with the provided app name.
 func NewNomadSource(client *api.Client, app string) *NomadSource {
 	return &NomadSource{
 		client: client,
@@ -25,19 +32,35 @@ func NewNomadSource(client *api.Client, app string) *NomadSource {
 	}
 }
 
+// List all targets within the Nomad cluster matching the application. This method will use the Nomad services API to
+// find services that have two main tags: autopgo.scrape=true and autopgo.scrape.app=app. The latter tag should use
+// the configured application name as the tag value. A custom path & scheme can be set using the autopgo.scrape.path
+// and autopgo.scrape.scheme tags.
 func (ns *NomadSource) List(ctx context.Context) ([]Target, error) {
+	log := logger.FromContext(ctx)
+
 	listOpts := &api.QueryOptions{
 		Namespace: api.AllNamespacesNamespace,
 		Filter:    ns.filter,
 	}
 
+	log.DebugContext(ctx, "listing nomad services")
 	resp, _, err := ns.client.Services().List(listOpts.WithContext(ctx))
 	if err != nil {
 		return nil, err
 	}
 
+	log.
+		With(slog.Int("count", len(resp))).
+		DebugContext(ctx, "found namespaces with tagged services")
+
 	targets := make([]Target, 0)
 	for _, entry := range resp {
+		log.With(
+			slog.Int("count", len(entry.Services)),
+			slog.String("namespace", entry.Namespace),
+		).DebugContext(ctx, "found tagged services")
+
 		for _, serviceEntry := range entry.Services {
 			getOpts := &api.QueryOptions{
 				Namespace: entry.Namespace,


### PR DESCRIPTION
This commit adds a few missing bits from the initial nomad support commit. Mainly missing documentation on the types/methods & logging that exists in the other target sources.