### PR TITLE
Don't run SIGHUP test in parallel

### DIFF
--- a/internal/target/file_test.go
+++ b/internal/target/file_test.go
@@ -73,8 +73,6 @@ func TestFileSource_List(t *testing.T) {
 }
 
 func TestFileSource_SIGHUP(t *testing.T) {
-	t.Parallel()
-
 	ctx, cancel := context.WithCancel(context.Background())
 	t.Cleanup(cancel)
 


### PR DESCRIPTION
This commit modifies the file target source SIGHUP test to no longer run in parallel. This might fix the flakiness.