### PR TITLE
Include license in distribution

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,5 +2,6 @@ FROM gcr.io/distroless/static
 
 COPY autopgo /usr/bin/autopgo
 COPY README.md /usr/bin/README.md
+COPY LICENSE /usr/bin/LICENSE
 
 CMD ["/usr/bin/autopgo"]

--- a/README.md
+++ b/README.md
@@ -191,8 +191,7 @@ added to their entry. The table below describes these tags and provides examples
 |  `autopgo.scrape.path`  | `autopgo.path: "/debug/pprof/profile"` |    No    | Allows for specifying the path to the pprof endpoint, defaults to /debug/pprof/profile. |
 | `autopgo.scrape.scheme` |        `autopgo.scheme: "http"`        |    No    | Informs the scraper whether the endpoint uses HTTP or HTTPS, defaults to HTTP.          |
 
-As in all other operating modes, a single scraper instance is required per application you wish to scrape. Below is an
-example of a Nomad job specification that contains a service with all usable tags:
+As in all other operating modes, a single scraper instance is required per application you wish to scrape.
 
 #### Sampling
 

--- a/goreleaser.yml
+++ b/goreleaser.yml
@@ -25,6 +25,7 @@ dockers:
       - "ghcr.io/davidsbond/autopgo:{{ .Tag }}-amd64"
     extra_files:
       - README.md
+      - LICENSE
     dockerfile: Dockerfile
     use: buildx
     build_flag_templates:
@@ -38,6 +39,7 @@ dockers:
       - "ghcr.io/davidsbond/autopgo:{{ .Tag }}-arm64"
     extra_files:
       - README.md
+      - LICENSE
     dockerfile: Dockerfile
     use: buildx
     build_flag_templates:
@@ -55,6 +57,7 @@ archives:
     name_template: "{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
     files:
       - README.md
+      - LICENSE
 
 checksum:
   name_template: "{{ .ProjectName }}_{{ .Version }}_SHA256SUMS"


### PR DESCRIPTION
This commit modifies the docker image and released artifacts to include the LICENSE file. It also removes a copy & paste error in the docs.