### PR TITLE
Add health & ready endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -505,3 +505,38 @@ table below:
 |   `--api-url`, `-u`   |   `AUTOPGO_API_URL`   | `http://localhost:8080` | The base URL of the profile server where the specified profile will be sent              |
 | `--older-than`, `-d`  | `AUTOPGO_OLDER_THAN`  |          None           | How long a profile must not have been updated for to be eligible for cleaning            |
 | `--larger-than`, `-s` | `AUTOPGO_LARGER_THAN` |          None           | The minimum size (in bytes) a profile must be to be eligible for cleaning                |
+
+## Operations
+
+This section contains information for use by those running the various autopgo components.
+
+### Health & Readiness
+
+Each component exposes both health and readiness endpoints at the `/api/health` and `/api/ready`
+paths respectively. These can be used by your operator of choice to handle health and readiness checks. The health
+endpoint's response contains specifics on the individual dependencies of that component and its own health. 
+
+Below is an example health check response from the server component:
+
+```json
+{
+  "status": "healthy",
+  "dependencies": [
+    {
+      "name": "blob",
+      "status": "healthy"
+    },
+    {
+      "name": "event-reader",
+      "status": "healthy"
+    },
+    {
+      "name": "event-writer",
+      "status": "healthy"
+    }
+  ]
+}
+```
+
+Health endpoints will return a `503` status code if one or more of the individual components are in an unhealthy state
+and a `message` field will be present with the error message received when checking that dependency's health.

--- a/cmd/scrape/scrape.go
+++ b/cmd/scrape/scrape.go
@@ -13,6 +13,7 @@ import (
 	"k8s.io/client-go/tools/clientcmd"
 
 	"github.com/davidsbond/autopgo/internal/logger"
+	"github.com/davidsbond/autopgo/internal/operation"
 	"github.com/davidsbond/autopgo/internal/profile"
 	"github.com/davidsbond/autopgo/internal/server"
 	"github.com/davidsbond/autopgo/internal/target"
@@ -53,7 +54,7 @@ func Command() *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := cmd.Context()
 
-			var source profile.TargetSource
+			var source target.Source
 			var err error
 
 			switch mode {
@@ -92,6 +93,11 @@ func Command() *cobra.Command {
 				return server.Run(ctx, server.Config{
 					Debug: debug,
 					Port:  port,
+					Controllers: []server.Controller{
+						operation.NewHTTPController([]operation.Checker{
+							source,
+						}),
+					},
 					Middleware: []server.Middleware{
 						logger.Middleware(logger.FromContext(ctx)),
 					},

--- a/cmd/server/server.go
+++ b/cmd/server/server.go
@@ -8,6 +8,7 @@ import (
 	"github.com/davidsbond/autopgo/internal/closers"
 	"github.com/davidsbond/autopgo/internal/event"
 	"github.com/davidsbond/autopgo/internal/logger"
+	"github.com/davidsbond/autopgo/internal/operation"
 	"github.com/davidsbond/autopgo/internal/profile"
 	"github.com/davidsbond/autopgo/internal/server"
 )
@@ -49,6 +50,10 @@ func Command() *cobra.Command {
 				Port:  port,
 				Controllers: []server.Controller{
 					profile.NewHTTPController(blobs, writer),
+					operation.NewHTTPController([]operation.Checker{
+						blobs,
+						writer,
+					}),
 				},
 				Middleware: []server.Middleware{
 					logger.Middleware(logger.FromContext(ctx)),

--- a/cmd/worker/worker.go
+++ b/cmd/worker/worker.go
@@ -9,6 +9,7 @@ import (
 	"github.com/davidsbond/autopgo/internal/closers"
 	"github.com/davidsbond/autopgo/internal/event"
 	"github.com/davidsbond/autopgo/internal/logger"
+	"github.com/davidsbond/autopgo/internal/operation"
 	"github.com/davidsbond/autopgo/internal/profile"
 	"github.com/davidsbond/autopgo/internal/server"
 )
@@ -82,6 +83,13 @@ func Command() *cobra.Command {
 				return server.Run(ctx, server.Config{
 					Debug: debug,
 					Port:  port,
+					Controllers: []server.Controller{
+						operation.NewHTTPController([]operation.Checker{
+							blobs,
+							reader,
+							writer,
+						}),
+					},
 					Middleware: []server.Middleware{
 						logger.Middleware(logger.FromContext(ctx)),
 					},

--- a/internal/blob/blob.go
+++ b/internal/blob/blob.go
@@ -149,3 +149,15 @@ func (b *Bucket) List(ctx context.Context, filter Filter) iter.Seq2[Object, erro
 func (b *Bucket) Exists(ctx context.Context, path string) (bool, error) {
 	return b.blob.Exists(ctx, path)
 }
+
+// Name returns "blob". This method is used to implement the operation.Checker interface for use in health checks.
+func (b *Bucket) Name() string {
+	return "blob"
+}
+
+// Check determines if the bucket is accessible. This method is used to implement the operation.Checker interface for
+// use in health checks.
+func (b *Bucket) Check(ctx context.Context) error {
+	_, err := b.blob.IsAccessible(ctx)
+	return err
+}

--- a/internal/operation/http.go
+++ b/internal/operation/http.go
@@ -1,0 +1,93 @@
+package operation
+
+import (
+	"net/http"
+
+	"github.com/davidsbond/autopgo/internal/api"
+)
+
+type (
+	// The HTTPController type is used to serve the health and readiness endpoints.
+	HTTPController struct {
+		healthChecks []Checker
+	}
+)
+
+// NewHTTPController returns a new instance of the HTTPController type that will serve the provided Checker
+// implementations as health checks.
+func NewHTTPController(healthChecks []Checker) *HTTPController {
+	return &HTTPController{
+		healthChecks: healthChecks,
+	}
+}
+
+// Register endpoints onto the http.ServeMux.
+func (h *HTTPController) Register(mux *http.ServeMux) {
+	mux.HandleFunc("GET /api/health", h.GetHealth)
+	mux.HandleFunc("GET /api/ready", h.GetReadiness)
+}
+
+type (
+	// The GetHealthResponse type contains fields describing the health of the application.
+	GetHealthResponse struct {
+		// The overall health status across all components.
+		Status HealthStatus `json:"status"`
+		// The status of individual dependencies.
+		Dependencies []Dependency `json:"dependencies"`
+	}
+)
+
+// GetHealth handles an inbound HTTP request that returns the current health status of the application and its
+// dependencies. The top-level status in the response will be HealthStatusUnhealthy if one or more of the dependencies
+// report the same status. When bad health is detected, the response code is 503.
+func (h *HTTPController) GetHealth(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+
+	resp := GetHealthResponse{
+		Status: HealthStatusHealthy,
+	}
+
+	for _, checker := range h.healthChecks {
+		component := Dependency{
+			Name:   checker.Name(),
+			Status: HealthStatusHealthy,
+		}
+
+		if err := checker.Check(ctx); err != nil {
+			component.Status = HealthyStatusUnhealthy
+			component.Message = err.Error()
+		}
+
+		resp.Dependencies = append(resp.Dependencies, component)
+	}
+
+	for _, component := range resp.Dependencies {
+		if component.Status != HealthStatusHealthy {
+			resp.Status = component.Status
+			break
+		}
+	}
+
+	switch resp.Status {
+	case HealthStatusHealthy:
+		api.Respond(ctx, w, http.StatusOK, resp)
+		return
+	case HealthyStatusUnhealthy:
+		api.Respond(ctx, w, http.StatusServiceUnavailable, resp)
+		return
+	}
+}
+
+type (
+	// The GetReadinessResponse type is the response given when calling the readiness endpoint.
+	GetReadinessResponse struct{}
+)
+
+// GetReadiness handles an inbound HTTP request to determine if the application is ready to handle HTTP traffic. This
+// endpoint currently just returns an empty response with a 200 code, as if this request can be served then
+// readiness is expected.
+func (h *HTTPController) GetReadiness(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+
+	api.Respond(ctx, w, http.StatusOK, GetReadinessResponse{})
+}

--- a/internal/operation/operation.go
+++ b/internal/operation/operation.go
@@ -1,0 +1,34 @@
+// Package operation provides types used to expose health, rediness & other general operator focused functionality.
+package operation
+
+import "context"
+
+type (
+	// The HealthStatus string denotes the current health of an application or its components.
+	HealthStatus string
+
+	// The Dependency type contains health data for an individual dependency within an application.
+	Dependency struct {
+		// The name of the component.
+		Name string `json:"name"`
+		// The status of the component.
+		Status HealthStatus `json:"status"`
+		// Any error message returned when checking the component's health.
+		Message string `json:"message,omitempty"`
+	}
+
+	// The Checker interface describes types whose health can be checked.
+	Checker interface {
+		// The Name of the check. This ends up used as Dependency.Name.
+		Name() string
+		// Check should return an error if the component is deemed unhealthy.
+		Check(ctx context.Context) error
+	}
+)
+
+// Constants for health statuses.
+const (
+	HealthStatusUnknown    HealthStatus = "unknown"
+	HealthStatusHealthy    HealthStatus = "healthy"
+	HealthyStatusUnhealthy HealthStatus = "unhealthy"
+)

--- a/internal/target/consul.go
+++ b/internal/target/consul.go
@@ -80,3 +80,19 @@ func (cs *ConsulSource) List(ctx context.Context) ([]Target, error) {
 
 	return targets, nil
 }
+
+// Name returns "consul". This method is used to implement the operation.Check interface for use in health checks.
+func (cs *ConsulSource) Name() string {
+	return "consul"
+}
+
+// Check attempts to list services within consul. This method is used to implement the operation.Check interface for use
+// in health checks.
+func (cs *ConsulSource) Check(ctx context.Context) error {
+	options := &api.QueryOptions{
+		Filter: cs.filter,
+	}
+
+	_, _, err := cs.client.Catalog().Services(options.WithContext(ctx))
+	return err
+}

--- a/internal/target/file.go
+++ b/internal/target/file.go
@@ -92,3 +92,16 @@ func readTargetsFromFile(ctx context.Context, location string) ([]Target, error)
 
 	return targets, nil
 }
+
+// Check performs os.Stat on the desired config file. This method is used to implement the operation.Checker interface
+// for use in health checks.
+func (fs *FileSource) Check(_ context.Context) error {
+	_, err := os.Stat(fs.location)
+	return err
+}
+
+// Name returns "file://<config location>". This method is used to implement the operation.Checker interface for use in
+// health checks.
+func (fs *FileSource) Name() string {
+	return "file://" + fs.location
+}

--- a/internal/target/kubernetes.go
+++ b/internal/target/kubernetes.go
@@ -111,3 +111,20 @@ func (ks *KubernetesSource) List(ctx context.Context) ([]Target, error) {
 
 	return targets, ctx.Err()
 }
+
+// Name returns "kubernetes". This method is used to implement the operation.Check interface for use in health checks.
+func (ks *KubernetesSource) Name() string {
+	return "kubernetes"
+}
+
+// Check attempts to list pods within kubernetes. This method is used to implement the operation.Checker interface for
+// use in health checks.
+func (ks *KubernetesSource) Check(ctx context.Context) error {
+	options := metav1.ListOptions{
+		LabelSelector: ks.labels.String(),
+		FieldSelector: ks.fields.String(),
+	}
+
+	_, err := ks.client.CoreV1().Pods(corev1.NamespaceAll).List(ctx, options)
+	return err
+}

--- a/internal/target/nomad.go
+++ b/internal/target/nomad.go
@@ -94,3 +94,20 @@ func (ns *NomadSource) List(ctx context.Context) ([]Target, error) {
 
 	return targets, nil
 }
+
+// Name returns "nomad". This method is used to implement the operation.Checker interface for use in health checks.
+func (ns *NomadSource) Name() string {
+	return "nomad"
+}
+
+// Check attempts to list services in nomad. This method is used to implement the operation.Checker interface for use in
+// health checks.
+func (ns *NomadSource) Check(ctx context.Context) error {
+	listOpts := &api.QueryOptions{
+		Namespace: api.AllNamespacesNamespace,
+		Filter:    ns.filter,
+	}
+
+	_, _, err := ns.client.Services().List(listOpts.WithContext(ctx))
+	return err
+}

--- a/internal/target/target.go
+++ b/internal/target/target.go
@@ -1,7 +1,12 @@
 // Package target provides types for managing sources of applications that can be scraped.
 package target
 
-import "strings"
+import (
+	"context"
+	"strings"
+
+	"github.com/davidsbond/autopgo/internal/operation"
+)
 
 type (
 	// The Target type describes individual instances of an application that can be scraped.
@@ -11,6 +16,14 @@ type (
 		// The path to the pprof profile endpoint, including leading slash. Defaults to /debug/pprof/profile if
 		// unset.
 		Path string `json:"path"`
+	}
+
+	// The Source interface describes types that can query scrapable targets from some system that stores them.
+	Source interface {
+		operation.Checker
+
+		// List should return all targets that can be scraped.
+		List(ctx context.Context) ([]Target, error)
 	}
 )
 

--- a/scripts/prepare-dev.sh
+++ b/scripts/prepare-dev.sh
@@ -14,3 +14,4 @@ export AUTOPGO_LOG_LEVEL=debug
 export AUTOPGO_API_URL="http://localhost:8080"
 export AUTOPGO_APP=autopgo
 export AUTOPGO_SAMPLE_SIZE=10
+export AUTOPGO_DEBUG=true


### PR DESCRIPTION
This commit modifies all components to now include health and readiness endpoints for operators to use when deploying the individual components.